### PR TITLE
Let the change-site modal create a new site at the placement

### DIFF
--- a/services/frontend/src/components/CameraDeploymentHistory.tsx
+++ b/services/frontend/src/components/CameraDeploymentHistory.tsx
@@ -5,7 +5,10 @@
  * each step is a site the camera moved to, oldest first. Site assignment is
  * automatic; corrections normally happen from the camera updates panel. As a
  * late-correction escape hatch, project admins get a "change site" action on
- * each step, which reassigns that placement to any site of the project.
+ * each step, which reassigns that placement to any site of the project, or to
+ * a brand new site created at the placement's own GPS. That new-site path is
+ * the only way to split a backlog site that the automatic clustering merged by
+ * mistake, since the feed's "new site" decision is not replayable for old data.
  */
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -15,6 +18,7 @@ import { camerasApi } from '../api/cameras';
 import { sitesApi } from '../api/sites';
 import { deploymentsApi } from '../api/deployments';
 import { DeploymentJourney, type JourneyItem } from './DeploymentJourney';
+import { SiteFormModal } from './sites/SiteFormModal';
 import { Button } from './ui/Button';
 import { Select } from './ui/Select';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/Dialog';
@@ -33,6 +37,7 @@ export const CameraDeploymentHistory: React.FC<{
 
   const [editItem, setEditItem] = useState<JourneyItem | null>(null);
   const [siteId, setSiteId] = useState<number | null>(null);
+  const [creatingSite, setCreatingSite] = useState(false);
 
   const { data, isLoading } = useQuery({
     queryKey: ['camera-deployments', cameraId],
@@ -45,8 +50,11 @@ export const CameraDeploymentHistory: React.FC<{
     enabled: pid !== undefined && editItem !== null,
   });
 
-  const saveMutation = useMutation({
-    mutationFn: () => deploymentsApi.update(pid!, editItem!.id, { site_id: siteId }),
+  // Reassign the edited placement to a site, by id. Shared by the "pick an
+  // existing site" dropdown and the "create a new site here" path.
+  const assignMutation = useMutation({
+    mutationFn: (targetSiteId: number) =>
+      deploymentsApi.update(pid!, editItem!.id, { site_id: targetSiteId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['camera-deployments'] });
       queryClient.invalidateQueries({ queryKey: ['sites', pid] });
@@ -69,6 +77,7 @@ export const CameraDeploymentHistory: React.FC<{
   }
 
   const deployments = data ?? [];
+  const editDep = editItem ? deployments.find((d) => d.id === editItem.id) : undefined;
 
   const openEdit = (item: JourneyItem) => {
     const dep = deployments.find((d) => d.id === item.id);
@@ -101,30 +110,56 @@ export const CameraDeploymentHistory: React.FC<{
                 this period. Its images move along to the new site.
               </DialogDescription>
             </DialogHeader>
-            <div className="py-4">
-              <label className="text-xs text-muted-foreground">Site</label>
-              <Select
-                value={siteId ?? ''}
-                onChange={(e) => setSiteId(e.target.value === '' ? null : Number(e.target.value))}
+            <div className="py-4 space-y-3">
+              <div>
+                <label className="text-xs text-muted-foreground">Site</label>
+                <Select
+                  value={siteId ?? ''}
+                  onChange={(e) => setSiteId(e.target.value === '' ? null : Number(e.target.value))}
+                >
+                  {(sites ?? []).map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <button
+                type="button"
+                onClick={() => setCreatingSite(true)}
+                className="text-sm text-primary hover:underline"
               >
-                {(sites ?? []).map((s) => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}
-                  </option>
-                ))}
-              </Select>
+                Or create a new site here
+              </button>
             </div>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setEditItem(null)} disabled={saveMutation.isPending}>
+              <Button variant="outline" onClick={() => setEditItem(null)} disabled={assignMutation.isPending}>
                 Cancel
               </Button>
-              <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || siteId == null}>
-                {saveMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              <Button onClick={() => assignMutation.mutate(siteId!)} disabled={assignMutation.isPending || siteId == null}>
+                {assignMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
                 Save
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
+      )}
+
+      {editItem && creatingSite && (
+        <SiteFormModal
+          open
+          onClose={() => setCreatingSite(false)}
+          projectId={pid!}
+          sites={sites ?? []}
+          defaultLat={editDep?.latitude ?? null}
+          defaultLon={editDep?.longitude ?? null}
+          onCreated={(site) => {
+            // Created at this placement's GPS: move the placement onto it, which
+            // splits it out of the site the automatic clustering had merged.
+            setCreatingSite(false);
+            assignMutation.mutate(site.id);
+          }}
+        />
       )}
     </>
   );


### PR DESCRIPTION
The change-site escape hatch could only reassign a placement to an existing site. When the automatic clustering merged two nearby cameras into one backlog site, there was no way to split them, because the feed's "new site" decision does not replay for old data.

Add a "create a new site here" action that opens the site form at the placement's own GPS, then moves the placement onto the new site. Reuses the existing SiteFormModal and deployments.update endpoint.